### PR TITLE
fix: csrf exempt

### DIFF
--- a/payment/views.py
+++ b/payment/views.py
@@ -15,6 +15,7 @@ from .models import Payment
 from .midtrans_service import MidtransService
 
 
+@csrf_exempt
 @login_required
 @require_http_methods(["GET"])
 def payment_method_selection(request, booking_id):
@@ -47,6 +48,7 @@ def payment_method_selection(request, booking_id):
     return render(request, 'payment/method_selection.html', context)
 
 
+@csrf_exempt
 @login_required
 @require_POST
 def process_payment(request, booking_id):
@@ -265,6 +267,7 @@ def mark_booking_as_paid(booking_id: int, payment_id: int, payment_method: str):
     return False
 
 
+@csrf_exempt
 def payment_callback(request):
     """
     Finish Redirect URL - Customer sent here if payment is successful
@@ -339,6 +342,7 @@ def payment_callback(request):
     return render(request, 'payment/callback.html', context)
 
 
+@csrf_exempt
 def payment_unfinish(request):
     """
     Unfinish Redirect URL - Customer sent here if they click 'Back to Order Website' 
@@ -390,6 +394,7 @@ def payment_unfinish(request):
     return render(request, 'payment/callback.html', context)
 
 
+@csrf_exempt
 def payment_error(request):
     """
     Error Redirect URL - Customer sent here if payment encounters an error
@@ -440,6 +445,7 @@ def payment_error(request):
     return render(request, 'payment/callback.html', context)
 
 
+@csrf_exempt
 @login_required
 def payment_status(request, payment_id):
     """


### PR DESCRIPTION
This pull request adds CSRF exemption to several payment-related view functions in `payment/views.py`. The main goal is to ensure these endpoints can be accessed by external services or clients that may not include CSRF tokens, particularly for payment callbacks and redirects.

Security and access control changes:

* Added `@csrf_exempt` decorator to the `payment_method_selection`, `process_payment`, `payment_callback`, `payment_unfinish`, `payment_error`, and `payment_status` view functions to allow requests without CSRF validation. [[1]](diffhunk://#diff-1c55ee01708d9be74c6e371e90b419ae0b3116fa01694c27d049bfb393bc4d17R18) [[2]](diffhunk://#diff-1c55ee01708d9be74c6e371e90b419ae0b3116fa01694c27d049bfb393bc4d17R51) [[3]](diffhunk://#diff-1c55ee01708d9be74c6e371e90b419ae0b3116fa01694c27d049bfb393bc4d17R270) [[4]](diffhunk://#diff-1c55ee01708d9be74c6e371e90b419ae0b3116fa01694c27d049bfb393bc4d17R345) [[5]](diffhunk://#diff-1c55ee01708d9be74c6e371e90b419ae0b3116fa01694c27d049bfb393bc4d17R397) [[6]](diffhunk://#diff-1c55ee01708d9be74c6e371e90b419ae0b3116fa01694c27d049bfb393bc4d17R448)